### PR TITLE
Add shared library link flag for Linux (tested with liblua5.4-dev under Debian)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,9 @@ fn main() {
 #[cfg(not(feature = "vendored"))]
 fn main() {
     let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    if family == "windows" {
-        println!("cargo:rustc-link-lib=lua54.dll");
+    match family.as_str() {
+	"windows" => println!("cargo:rustc-link-lib=lua54.dll"),
+	"unix" => println!("cargo:rustc-link-lib=lua5.4"),
+	_ => ()
     }
 }


### PR DESCRIPTION
Won't compile under Linux otherwise (without the vendored feature)